### PR TITLE
feat: procmon library to monitor system calls

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -181,6 +181,8 @@ include src/main/p4ioemu/Module.mk
 include src/main/popnhook-util/Module.mk
 include src/main/popnhook1/Module.mk
 include src/main/popnio/Module.mk
+include src/main/procmon/Module.mk
+include src/main/procmon-lib/Module.mk
 include src/main/pcbidgen/Module.mk
 include src/main/sdvxhook/Module.mk
 include src/main/sdvxhook2-cn/Module.mk
@@ -232,6 +234,7 @@ $(zipdir)/tools.zip: \
 		build/bin/indep-32/ezusb2-dbg-hook.dll \
 		build/bin/indep-32/ezusb2-tool.exe \
 		build/bin/indep-32/ezusb-tool.exe \
+		build/bin/indep-32/procmon.dll \
 		| $(zipdir)/
 	$(V)echo ... $@
 	$(V)zip -j $@ $^
@@ -246,6 +249,7 @@ $(zipdir)/tools-x64.zip: \
 		build/bin/indep-64/iidx-ezusb2-exit-hook.dll \
 		build/bin/indep-64/jbiotest.exe \
 		build/bin/indep-64/mempatch-hook.dll \
+		build/bin/indep-64/procmon.dll \
 		| $(zipdir)/
 	$(V)echo ... $@
 	$(V)zip -j $@ $^

--- a/src/main/hook/table.c
+++ b/src/main/hook/table.c
@@ -15,7 +15,16 @@ static const size_t apiset_prefix_len = sizeof(apiset_prefix) - 1;
 static void hook_table_apply_to_all(
     const char *depname, const struct hook_symbol *syms, size_t nsyms);
 
+static void hook_table_revert_to_all(
+    const char *depname, const struct hook_symbol *syms, size_t nsyms);
+
 static void hook_table_apply_to_iid(
+    HMODULE target,
+    const pe_iid_t *iid,
+    const struct hook_symbol *syms,
+    size_t nsyms);
+
+static void hook_table_revert_to_iid(
     HMODULE target,
     const pe_iid_t *iid,
     const struct hook_symbol *syms,
@@ -41,6 +50,23 @@ static void hook_table_apply_to_all(
         }
 
         hook_table_apply(pe, depname, syms, nsyms);
+    }
+}
+
+static void hook_table_revert_to_all(
+    const char *depname, const struct hook_symbol *syms, size_t nsyms)
+{
+    const peb_dll_t *dll;
+    HMODULE pe;
+
+    for (dll = peb_dll_get_first(); dll != NULL; dll = peb_dll_get_next(dll)) {
+        pe = peb_dll_get_base(dll);
+
+        if (pe == NULL) {
+            continue; /* ?? Happens sometimes. */
+        }
+
+        hook_table_revert(pe, depname, syms, nsyms);
     }
 }
 
@@ -73,6 +99,35 @@ void hook_table_apply(
     }
 }
 
+void hook_table_revert(
+    HMODULE target,
+    const char *depname,
+    const struct hook_symbol *syms,
+    size_t nsyms)
+{
+    const pe_iid_t *iid;
+    const char *iid_name;
+
+    assert(depname != NULL);
+    assert(syms != NULL || nsyms == 0);
+
+    if (target == NULL) {
+        /*  Call out, which will then call us back repeatedly. Awkward, but
+            viewed from the outside it's good for usability. */
+
+        hook_table_revert_to_all(depname, syms, nsyms);
+    } else {
+        for (iid = pe_iid_get_first(target); iid != NULL;
+             iid = pe_iid_get_next(target, iid)) {
+            iid_name = pe_iid_get_name(target, iid);
+
+            if (hook_table_match_module(target, iid_name, depname)) {
+                hook_table_revert_to_iid(target, iid, syms, nsyms);
+            }
+        }
+    }
+}
+
 static void hook_table_apply_to_iid(
     HMODULE target,
     const pe_iid_t *iid,
@@ -96,6 +151,33 @@ static void hook_table_apply_to_iid(
                 }
 
                 pe_patch(iate.ppointer, &sym->patch, sizeof(sym->patch));
+            }
+        }
+    }
+}
+
+static void hook_table_revert_to_iid(
+    HMODULE target,
+    const pe_iid_t *iid,
+    const struct hook_symbol *syms,
+    size_t nsyms)
+{
+    struct pe_iat_entry iate;
+    size_t i;
+    size_t j;
+    const struct hook_symbol *sym;
+
+    i = 0;
+
+    while (pe_iid_get_iat_entry(target, iid, i++, &iate) == S_OK) {
+        for (j = 0; j < nsyms; j++) {
+            sym = &syms[j];
+
+            if (hook_table_match_proc(&iate, sym)) {
+                // Only revert-able if the original pointer was stored previously
+                if (sym->link != NULL && *sym->link != NULL) {
+                    pe_patch(iate.ppointer, sym->link, sizeof(*sym->link));
+                } 
             }
         }
     }

--- a/src/main/launcher/Module.mk
+++ b/src/main/launcher/Module.mk
@@ -14,6 +14,7 @@ libs_launcher   := \
     hook \
     util \
     dwarfstack \
+    procmon-lib \
 
 src_launcher    := \
     avs-config.c \

--- a/src/main/launcher/launcher-config.c
+++ b/src/main/launcher/launcher-config.c
@@ -15,8 +15,14 @@
 PSMAP_BEGIN(launcher_debug_psmap)
 PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, remote_debugger,
     "debug/remote_debugger", false)
-    PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, log_property_configs,
+PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, log_property_configs,
     "debug/log_property_configs", false)
+PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, procmon_file,
+    "debug/procmon/file", false)
+PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, procmon_module,
+    "debug/procmon/module", false)
+PSMAP_OPTIONAL(PSMAP_TYPE_BOOL, struct launcher_debug_config, procmon_thread,
+    "debug/procmon/thread", false)
 PSMAP_END
 // clang-format on
 
@@ -192,6 +198,9 @@ void launcher_config_init(struct launcher_config *config)
 
     config->debug.remote_debugger = false;
     config->debug.log_property_configs = false;
+    config->debug.procmon_file = false;
+    config->debug.procmon_module = false;
+    config->debug.procmon_thread = false;
 }
 
 void launcher_config_load(

--- a/src/main/launcher/launcher-config.h
+++ b/src/main/launcher/launcher-config.h
@@ -36,6 +36,9 @@ struct launcher_config {
     struct launcher_debug_config {
         bool remote_debugger;
         bool log_property_configs;
+        bool procmon_file;
+        bool procmon_module;
+        bool procmon_thread;
     } debug;
 };
 

--- a/src/main/launcher/launcher.c
+++ b/src/main/launcher/launcher.c
@@ -26,6 +26,8 @@
 #include "launcher/property-util.h"
 #include "launcher/stubs.h"
 
+#include "procmon-lib/procmon.h"
+
 #include "util/debug.h"
 #include "util/defs.h"
 #include "util/fs.h"
@@ -232,6 +234,32 @@ _launcher_remote_debugger_trap(const struct launcher_debug_config *config)
     }
 }
 
+static void _launcher_procmon_init(
+    const struct launcher_debug_config *config,
+    struct procmon *procmon)
+{
+    procmon_init(procmon);
+
+    if (procmon_available()) {
+        procmon_load(procmon);
+
+        procmon->set_loggers(log_impl_misc, log_impl_info, log_impl_warning, log_impl_fatal);
+        procmon->init();
+
+        if (config->procmon_file) {
+            procmon->file_mon_enable();
+        }
+
+        if (config->procmon_module) {
+            procmon->module_mon_enable();
+        }
+
+        if (config->procmon_thread) {
+            procmon->thread_mon_enable();
+        }
+    }
+}
+
 static void _launcher_bootstrap_config_load(
     const struct launcher_bootstrap_config *launcher_bootstrap_config,
     struct bootstrap_config *config)
@@ -397,7 +425,8 @@ void _launcher_init(
     const struct options *options,
     struct launcher_config *launcher_config,
     struct bootstrap_config *bootstrap_config,
-    struct ea3_ident_config *ea3_ident_config)
+    struct ea3_ident_config *ea3_ident_config,
+    struct procmon *procmon)
 {
     struct property *launcher_property;
 
@@ -447,6 +476,8 @@ void _launcher_init(
     _launcher_config_full_resolved_log(launcher_config);
 
     _launcher_remote_debugger_trap(&launcher_config->debug);
+
+    _launcher_procmon_init(&launcher_config->debug, procmon);
 
     _launcher_bootstrap_config_load(
         &launcher_config->bootstrap, bootstrap_config);
@@ -508,16 +539,22 @@ void _launcher_run(
 
 void _launcher_fini(
     struct launcher_config *launcher_config,
-    const struct bootstrap_config *bootstrap_config)
+    const struct bootstrap_config *bootstrap_config,
+    struct procmon *procmon)
 {
     log_assert(launcher_config);
     log_assert(bootstrap_config);
+    log_assert(procmon);
 
     bootstrap_eamuse_fini(&bootstrap_config->startup.eamuse);
 
     bootstrap_avs_fini();
 
     bootstrap_module_game_fini();
+
+    if (procmon->module != NULL) {
+        procmon_free(procmon);
+    }
 
     launcher_config_fini(launcher_config);
 
@@ -531,13 +568,14 @@ void launcher_main(const struct options *options)
     struct launcher_config launcher_config;
     struct bootstrap_config bootstrap_config;
     struct ea3_ident_config ea3_ident_config;
+    struct procmon procmon;
 
     log_assert(options);
 
     _launcher_init(
-        options, &launcher_config, &bootstrap_config, &ea3_ident_config);
+        options, &launcher_config, &bootstrap_config, &ea3_ident_config, &procmon);
 
     _launcher_run(&launcher_config, &bootstrap_config, &ea3_ident_config);
 
-    _launcher_fini(&launcher_config, &bootstrap_config);
+    _launcher_fini(&launcher_config, &bootstrap_config, &procmon);
 }

--- a/src/main/procmon-lib/Module.mk
+++ b/src/main/procmon-lib/Module.mk
@@ -1,0 +1,8 @@
+libs		+= procmon-lib
+
+libs_procmon-lib	:= \
+	util \
+
+src_procmon-lib	:= \
+	procmon.c \
+

--- a/src/main/procmon-lib/procmon.c
+++ b/src/main/procmon-lib/procmon.c
@@ -1,0 +1,87 @@
+#define LOG_MODULE "procmon-lib"
+
+#include <windows.h>
+
+#include "procmon-lib/procmon.h"
+
+#include "util/log.h"
+
+#define PROCMON_LIB "procmon.dll"
+#define CONCAT(x, y) x ## y
+#define LOAD_FUNC(lib_func, module, path, func_name) \
+    lib_func = (CONCAT(func_name, _t)) GetProcAddress(module, #func_name); \
+    if (lib_func == NULL) { \
+        log_fatal("Failed to load function '%s' from '%s'", #func_name, path); \
+    }
+
+bool procmon_available()
+{
+    HMODULE module;
+
+    module = LoadLibraryExA(PROCMON_LIB, NULL, DONT_RESOLVE_DLL_REFERENCES);
+
+    if (module == NULL) {
+        return false;
+    } else {
+        FreeLibrary(module);
+        return true;
+    }
+}
+
+void procmon_init(struct procmon *procmon)
+{
+    log_assert(procmon);
+
+    memset(procmon, 0, sizeof(*procmon));
+}
+
+void procmon_load(struct procmon *procmon)
+{
+    HMODULE module;
+    uint32_t api_version;
+
+    log_assert(procmon);
+
+    module = LoadLibraryA(PROCMON_LIB);
+
+    if (module == NULL) {
+        LPSTR buffer;
+
+        FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL,
+            GetLastError(),
+            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            (LPSTR) &buffer,
+            0,
+            NULL);
+
+        log_fatal("Failed to load library %s: %s", PROCMON_LIB, buffer);
+
+        LocalFree(buffer);
+    }
+
+    procmon->module = module;
+
+    LOAD_FUNC(procmon->api_version, module, PROCMON_LIB, procmon_api_version);
+
+    api_version = procmon->api_version();
+
+    if (api_version != 0) {
+        log_fatal("Unsupported API version %d of %s", api_version, PROCMON_LIB);
+    }
+
+    LOAD_FUNC(procmon->set_loggers, module, PROCMON_LIB, procmon_set_loggers);
+    LOAD_FUNC(procmon->init, module, PROCMON_LIB, procmon_init);
+    LOAD_FUNC(procmon->file_mon_enable, module, PROCMON_LIB, procmon_file_mon_enable);
+    LOAD_FUNC(procmon->module_mon_enable, module, PROCMON_LIB, procmon_module_mon_enable);
+    LOAD_FUNC(procmon->thread_mon_enable, module, PROCMON_LIB, procmon_thread_mon_enable);
+}
+
+void procmon_free(struct procmon *procmon)
+{
+    log_assert(procmon);
+
+    FreeLibrary(procmon->module);
+}

--- a/src/main/procmon-lib/procmon.h
+++ b/src/main/procmon-lib/procmon.h
@@ -1,0 +1,37 @@
+#ifndef PROCMON_LIB_PROCMON_H
+#define PROCMON_LIB_PROCMON_H
+
+#include <windows.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "util/log.h"
+
+typedef uint32_t (*procmon_api_version_t)();
+typedef void (*procmon_set_loggers_t)(
+    log_formatter_t misc,
+    log_formatter_t info,
+    log_formatter_t warning,
+    log_formatter_t fatal);
+typedef void (*procmon_file_mon_enable_t)();
+typedef void (*procmon_module_mon_enable_t)();
+typedef void (*procmon_thread_mon_enable_t)();
+typedef void (*procmon_init_t)();
+
+struct procmon {
+    HMODULE module;
+    procmon_api_version_t api_version;
+    procmon_set_loggers_t set_loggers;
+    procmon_file_mon_enable_t file_mon_enable;
+    procmon_module_mon_enable_t module_mon_enable;
+    procmon_thread_mon_enable_t thread_mon_enable;
+    procmon_init_t init;
+};
+
+void procmon_init(struct procmon *procmon);
+bool procmon_available();
+void procmon_load(struct procmon *procmon);
+void procmon_free(struct procmon *procmon);
+
+#endif

--- a/src/main/procmon/Module.mk
+++ b/src/main/procmon/Module.mk
@@ -1,0 +1,12 @@
+dlls		+= procmon
+
+libs_procmon	:= \
+	hook \
+	util \
+
+src_procmon	:= \
+	file.c \
+	module.c \
+	procmon.c \
+	thread.c \
+

--- a/src/main/procmon/file.c
+++ b/src/main/procmon/file.c
@@ -1,0 +1,120 @@
+#define LOG_MODULE "procmon-file"
+
+#include <windows.h>
+
+#include "hook/table.h"
+
+#include "util/log.h"
+#include "util/str.h"
+
+static HANDLE (STDCALL *real_CreateFileW)(
+    const wchar_t *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile);
+static HANDLE (STDCALL *real_CreateFileA)(
+    const char *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile);
+
+static HANDLE STDCALL my_CreateFileW(
+    const wchar_t *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile);
+
+static HANDLE STDCALL my_CreateFileA(
+    const char *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile);
+
+static const struct hook_symbol _procmon_file_hook_syms[] = {
+    {
+        .name = "CreateFileW",
+        .patch = my_CreateFileW,
+        .link = (void **) &real_CreateFileW,
+    },
+    {
+        .name = "CreateFileA",
+        .patch = my_CreateFileA,
+        .link = (void **) &real_CreateFileA,
+    },
+};
+
+static HANDLE STDCALL my_CreateFileW(
+    const wchar_t *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile)
+{
+    HANDLE result;
+    char *tmp;
+
+    wstr_narrow(lpFileName, &tmp);
+
+    log_misc("CreateFileW(lpFileName %s, dwDesiredAccess 0x%X, dwShareMode 0x%X, dwCreationDisposition 0x%X, dwFlagsAndAttributes 0x%X, hTemplateFile %p)",
+        tmp, dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+
+    result = real_CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+
+    log_misc("CreateFileW(lpFileName %s, dwDesiredAccess 0x%X, dwShareMode 0x%X, dwCreationDisposition 0x%X, dwFlagsAndAttributes 0x%X, hTemplateFile %p) = %p",
+        tmp, dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile, result);
+
+    free(tmp);
+
+    return result;
+}
+
+static HANDLE STDCALL my_CreateFileA(
+    const char *lpFileName,
+    uint32_t dwDesiredAccess,
+    uint32_t dwShareMode,
+    SECURITY_ATTRIBUTES *lpSecurityAttributes,
+    uint32_t dwCreationDisposition,
+    uint32_t dwFlagsAndAttributes,
+    HANDLE hTemplateFile)
+{
+    HANDLE result;
+
+    log_misc("CreateFileA(lpFileName %s, dwDesiredAccess 0x%X, dwShareMode 0x%X, dwCreationDisposition 0x%X, dwFlagsAndAttributes 0x%X, hTemplateFile %p)",
+        lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+
+    result = real_CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+
+    log_misc("CreateFileA(lpFileName %s, dwDesiredAccess 0x%X, dwShareMode 0x%X, dwCreationDisposition 0x%X, dwFlagsAndAttributes 0x%X, hTemplateFile %p) = %p",
+        lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile, result);
+
+    return result;
+}
+
+void procmon_file_init()
+{
+    hook_table_apply(
+        NULL, "kernel32.dll", _procmon_file_hook_syms, lengthof(_procmon_file_hook_syms));
+
+    log_misc("init");
+}
+
+void procmon_file_fini()
+{
+    hook_table_revert(NULL, "kernel32.dll", _procmon_file_hook_syms, lengthof(_procmon_file_hook_syms));
+
+    log_misc("fini");
+}

--- a/src/main/procmon/file.h
+++ b/src/main/procmon/file.h
@@ -1,0 +1,7 @@
+#ifndef PROCMON_FILE_H
+#define PROCMON_FILE_H
+
+void procmon_file_init();
+void procmon_file_fini();
+
+#endif

--- a/src/main/procmon/module.c
+++ b/src/main/procmon/module.c
@@ -1,0 +1,229 @@
+#define LOG_MODULE "procmon-module"
+
+#include <windows.h>
+
+#include "hook/table.h"
+
+#include "util/log.h"
+#include "util/str.h"
+
+static HMODULE (STDCALL *real_GetModuleHandleA)(LPCSTR lpModuleName);
+static BOOL (STDCALL *real_GetModuleHandleExA)(DWORD dwFlags, LPCSTR lpModuleName, HMODULE *phModule);
+static BOOL (STDCALL *real_GetModuleHandleExW)(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE *phModule);
+static HMODULE (STDCALL *real_GetModuleHandleW)(LPCWSTR lpModuleName);
+static HMODULE (STDCALL *real_LoadLibraryA)(LPCSTR lpLibFileName);
+static HMODULE (STDCALL *real_LoadLibraryW)(LPCWSTR lpLibFileName);
+static HMODULE (STDCALL *real_LoadLibraryExA)(LPCSTR lpLibFileName, HANDLE hFile, DWORD  dwFlags);
+static HMODULE (STDCALL *real_LoadLibraryExW)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD  dwFlags);
+static FARPROC (STDCALL *real_GetProcAddress)(HMODULE hModule, LPCSTR  lpProcName);
+
+static HMODULE STDCALL my_GetModuleHandleA(LPCSTR lpModuleName);
+static BOOL STDCALL my_GetModuleHandleExA(DWORD dwFlags, LPCSTR lpModuleName, HMODULE *phModule);
+static BOOL STDCALL my_GetModuleHandleExW(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE *phModule);
+static HMODULE STDCALL my_GetModuleHandleW(LPCWSTR lpModuleName);
+static HMODULE STDCALL my_LoadLibraryA(LPCSTR lpLibFileName);
+static HMODULE STDCALL my_LoadLibraryW(LPCWSTR lpLibFileName);
+static HMODULE STDCALL my_LoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD  dwFlags);
+static HMODULE STDCALL my_LoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD  dwFlags);
+static FARPROC STDCALL my_GetProcAddress(HMODULE hModule, LPCSTR  lpProcName);
+
+static const struct hook_symbol _procmon_module_hook_syms[] = {
+    {
+        .name = "GetModuleHandleA",
+        .patch = my_GetModuleHandleA,
+        .link = (void **) &real_GetModuleHandleA,
+    },
+    {
+        .name = "GetModuleHandleExA",
+        .patch = my_GetModuleHandleExA,
+        .link = (void **) &real_GetModuleHandleExA,
+    },
+    {
+        .name = "GetModuleHandleExW",
+        .patch = my_GetModuleHandleExW,
+        .link = (void **) &real_GetModuleHandleExW,
+    },
+    {
+        .name = "GetModuleHandleW",
+        .patch = my_GetModuleHandleW,
+        .link = (void **) &real_GetModuleHandleW,
+    },
+    {
+        .name = "LoadLibraryA",
+        .patch = my_LoadLibraryA,
+        .link = (void **) &real_LoadLibraryA,
+    },
+    {
+        .name = "LoadLibraryW",
+        .patch = my_LoadLibraryW,
+        .link = (void **) &real_LoadLibraryW,
+    },
+    {
+        .name = "LoadLibraryExA",
+        .patch = my_LoadLibraryExA,
+        .link = (void **) &real_LoadLibraryExA,
+    },
+    {
+        .name = "LoadLibraryExW",
+        .patch = my_LoadLibraryExW,
+        .link = (void **) &real_LoadLibraryExW,
+    },
+    {
+        .name = "GetProcAddress",
+        .patch = my_GetProcAddress,
+        .link = (void **) &real_GetProcAddress,
+    },
+};
+
+static HMODULE STDCALL my_GetModuleHandleA(LPCSTR lpModuleName)
+{
+    HMODULE result;
+
+    log_misc("GetModuleHandleA(lpModuleName %s)", lpModuleName);
+
+    result = real_GetModuleHandleA(lpModuleName);
+
+    log_misc("GetModuleHandleA(lpModuleName %s) = %p", lpModuleName, result);
+
+    return result;
+}
+
+static BOOL STDCALL my_GetModuleHandleExA(DWORD dwFlags, LPCSTR lpModuleName, HMODULE *phModule)
+{
+    BOOL result;
+
+    log_misc("GetModuleHandleExA(dwFlags %lu, lpModuleName %s, phModule %p)", dwFlags, lpModuleName, phModule);
+
+    result = real_GetModuleHandleExA(dwFlags, lpModuleName, phModule);
+
+    log_misc("GetModuleHandleExA(dwFlags %lu, lpModuleName %s, phModule %p) = %d", dwFlags, lpModuleName, phModule, result);
+
+    return result;
+}
+
+static BOOL STDCALL my_GetModuleHandleExW(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE *phModule)
+{
+    BOOL result;
+    char *tmp;
+
+    wstr_narrow(lpModuleName, &tmp);
+
+    log_misc("GetModuleHandleExW(dwFlags %lu, lpModuleName %s, phModule %p)", dwFlags, tmp, phModule);
+
+    result = real_GetModuleHandleExW(dwFlags, lpModuleName, phModule);
+
+    log_misc("GetModuleHandleExW(dwFlags %lu, lpModuleName %s, phModule %p) = %d", dwFlags, tmp, phModule, result);
+
+    free(tmp);
+
+    return result;
+}
+
+static HMODULE STDCALL my_GetModuleHandleW(LPCWSTR lpModuleName)
+{
+    HMODULE result;
+    char *tmp;
+
+    wstr_narrow(lpModuleName, &tmp);
+
+    log_misc("GetModuleHandleW(lpModuleName %s)", tmp);
+
+    result = real_GetModuleHandleW(lpModuleName);
+
+    log_misc("GetModuleHandleW(lpModuleName %s) = %p", tmp, result);
+
+    free(tmp);
+
+    return result;
+}
+
+static HMODULE STDCALL my_LoadLibraryA(LPCSTR lpLibFileName)
+{
+    HMODULE result;
+
+    log_misc("LoadLibraryA(lpLibFileName %s)", lpLibFileName);
+
+    result = real_LoadLibraryA(lpLibFileName);
+
+    log_misc("LoadLibraryA(lpLibFileName %s) = %p", lpLibFileName, result);
+
+    return result;
+}
+
+static HMODULE STDCALL my_LoadLibraryW(LPCWSTR lpLibFileName)
+{
+    HMODULE result;
+    char *tmp;
+
+    wstr_narrow(lpLibFileName, &tmp);
+
+    log_misc("LoadLibraryW(lpLibFileName %s)", tmp);
+
+    result = real_LoadLibraryW(lpLibFileName);
+
+    log_misc("LoadLibraryW(lpLibFileName %s) = %p", tmp, result);
+
+    free(tmp);
+
+    return result;
+}
+
+static HMODULE STDCALL my_LoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    HMODULE result;
+
+    log_misc("LoadLibraryExA(lpLibFileName %s, hFile %p, dwFlags %lu)", lpLibFileName, hFile, dwFlags);
+
+    result = real_LoadLibraryExA(lpLibFileName, hFile, dwFlags);
+
+    log_misc("LoadLibraryExA(lpLibFileName %s, hFile %p, dwFlags %lu) = %p", lpLibFileName, hFile, dwFlags, result);
+
+    return result;
+}
+
+static HMODULE STDCALL my_LoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    HMODULE result;
+    char *tmp;
+
+    wstr_narrow(lpLibFileName, &tmp);
+
+    log_misc("LoadLibraryExA(lpLibFileName %s, hFile %p, dwFlags %lu)", tmp, hFile, dwFlags);
+
+    result = real_LoadLibraryExW(lpLibFileName, hFile, dwFlags);
+
+    log_misc("LoadLibraryExA(lpLibFileName %s, hFile %p, dwFlags %lu) = %p", tmp, hFile, dwFlags, result);
+
+    free(tmp);
+
+    return result;
+}
+
+static FARPROC STDCALL my_GetProcAddress(HMODULE hModule, LPCSTR lpProcName)
+{
+    FARPROC result;
+
+    log_misc("GetProcAddress(hModule %p, lpProcName %s)", hModule, lpProcName);
+
+    result = real_GetProcAddress(hModule, lpProcName);
+
+    log_misc("GetProcAddress(hModule %p, lpProcName %s = %p", hModule, lpProcName, result);
+
+    return result;
+}
+
+void procmon_module_init()
+{
+    hook_table_apply(
+        NULL, "kernel32.dll", _procmon_module_hook_syms, lengthof(_procmon_module_hook_syms));
+
+    log_misc("init");
+}
+
+void procmon_module_fini()
+{
+    hook_table_revert(
+        NULL, "kernel32.dll", _procmon_module_hook_syms, lengthof(_procmon_module_hook_syms));
+    
+    log_misc("fini");
+}

--- a/src/main/procmon/module.h
+++ b/src/main/procmon/module.h
@@ -1,0 +1,7 @@
+#ifndef PROCMON_MODULE_H
+#define PROCMON_MODULE_H
+
+void procmon_module_init();
+void procmon_module_fini();
+
+#endif

--- a/src/main/procmon/procmon.c
+++ b/src/main/procmon/procmon.c
@@ -1,0 +1,71 @@
+#define LOG_MODULE "procmon"
+
+#include <stdbool.h>
+
+#include "procmon/file.h"
+#include "procmon/module.h"
+#include "procmon/thread.h"
+
+#include "util/log.h"
+
+static bool _procmon_file_mon_enabled;
+static bool _procmon_module_mon_enabled;
+static bool _procmon_thread_mon_enabled;
+
+uint32_t procmon_api_version()
+{
+    return 0;
+}
+
+void procmon_set_loggers(
+    log_formatter_t misc,
+    log_formatter_t info,
+    log_formatter_t warning,
+    log_formatter_t fatal)
+{
+    log_to_external(misc, info, warning, fatal);
+}
+
+void procmon_init()
+{
+    _procmon_file_mon_enabled = false;
+    _procmon_module_mon_enabled = false;
+    _procmon_thread_mon_enabled = false;
+
+    log_info("init");
+}
+
+void procmon_file_mon_enable()
+{
+    procmon_file_init();
+    _procmon_file_mon_enabled = true;
+}
+
+void procmon_module_mon_enable()
+{
+    procmon_module_init();
+    _procmon_module_mon_enabled = true;
+}
+
+void procmon_thread_mon_enable()
+{
+    procmon_thread_init();
+    _procmon_thread_mon_enabled = true;
+}
+
+void procmon_fini()
+{
+    if (_procmon_file_mon_enabled) {
+        procmon_file_fini();
+    }
+
+    if (_procmon_module_mon_enabled) {
+        procmon_module_fini();
+    }
+
+    if (_procmon_thread_mon_enabled) {
+        procmon_thread_fini();
+    }
+
+    log_info("fini");
+}

--- a/src/main/procmon/procmon.def
+++ b/src/main/procmon/procmon.def
@@ -1,0 +1,10 @@
+LIBRARY procmon
+
+EXPORTS
+    procmon_api_version
+    procmon_set_loggers
+    procmon_init
+    procmon_file_mon_enable
+    procmon_module_mon_enable
+    procmon_thread_mon_enable
+    procmon_fini

--- a/src/main/procmon/procmon.h
+++ b/src/main/procmon/procmon.h
@@ -1,0 +1,21 @@
+#ifndef PROCMON_PROCMON_H
+#define PROCMON_PROCMON_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "util/log.h"
+
+uint32_t procmon_api_version();
+void procmon_set_loggers(
+    log_formatter_t misc,
+    log_formatter_t info,
+    log_formatter_t warning,
+    log_formatter_t fatal);
+void procmon_init();
+void procmon_file_mon_enable();
+void procmon_module_mon_enable();
+void procmon_thread_mon_enable();
+void procmon_fini();
+
+#endif

--- a/src/main/procmon/thread.c
+++ b/src/main/procmon/thread.c
@@ -1,0 +1,59 @@
+#define LOG_MODULE "procmon-thread"
+
+#include <windows.h>
+
+#include "hook/table.h"
+
+#include "util/log.h"
+
+#ifdef _WIN64
+    #define SIZE_T_FORMAT_SPECIFIER "llu"
+#else
+    #define SIZE_T_FORMAT_SPECIFIER "lu"
+#endif
+
+static HANDLE (STDCALL *real_CreateThread)(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize, 
+LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId);
+
+static HANDLE STDCALL my_CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize, 
+LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId);
+
+static const struct hook_symbol _procmon_thread_hook_syms[] = {
+    {
+        .name = "CreateThread",
+        .patch = my_CreateThread,
+        .link = (void **) &real_CreateThread,
+    },
+};
+
+static HANDLE STDCALL my_CreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize,
+    LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId)
+{
+    HANDLE result;
+
+    log_misc("CreateThread(lpThreadAttributes %p, dwStackSize %" SIZE_T_FORMAT_SPECIFIER ", lpStartAddress %p, lpParameter %p, dwCreationFlags %lu, lpThreadId %p)",
+        lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId);
+
+    result = real_CreateThread(lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId);
+
+    log_misc("CreateThread(lpThreadAttributes %p, dwStackSize %" SIZE_T_FORMAT_SPECIFIER ", lpStartAddress %p, lpParameter %p, dwCreationFlags %lu, lpThreadId %p) = %p, tid %lu",
+        lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId, result, lpThreadId ? *lpThreadId : -1);
+
+    return result;
+}
+
+void procmon_thread_init()
+{
+    hook_table_apply(
+        NULL, "kernel32.dll", _procmon_thread_hook_syms, lengthof(_procmon_thread_hook_syms));
+
+    log_misc("init");
+}
+
+void procmon_thread_fini()
+{
+    hook_table_revert(
+        NULL, "kernel32.dll", _procmon_thread_hook_syms, lengthof(_procmon_thread_hook_syms));
+
+    log_misc("fini");
+}

--- a/src/main/procmon/thread.h
+++ b/src/main/procmon/thread.h
@@ -1,0 +1,7 @@
+#ifndef PROCMON_THREAD_H
+#define PROCMON_THREAD_H
+
+void procmon_thread_init();
+void procmon_thread_fini();
+
+#endif


### PR DESCRIPTION
A general debugging tool. 3rd party applications such as
"procmon" (same name) provide these capabilites and even
more. But, they are more difficult to run with bemanitools
and don't provide a unified look at the output in combination
with the log output by bemanitools.

Provide an initial set of system call hooks that have already
supported debugging efforts. More can be added when needed
later.

Integrate this as an optional dependency into launcher and
load it dynamically. Thus, these can be easily loaded/enabled
by developers and end-users.